### PR TITLE
Make license use SPDX identifier

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
 
   <maintainer email="tzur.soffer@gmail">Tzur Soffer</maintainer>
 
-  <license file="LICENSE">GNU</license>
+  <license file="LICENSE">GPL-2.0-or-later</license>
 
   <url branch="main" type="repository">https://github.com/TzurSoffer/FreecadDiscordPresence</url>
 


### PR DESCRIPTION
The Addon Manager requires that the `license` entry use an SPDX identifier: https://spdx.org/licenses/