### PR TITLE
README: tweaked contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,31 @@
-# FreeCAD Discord Rich Presence Extension
+# FreeCAD Discord Rich Presence Addon
 
-This extension integrates Discord Rich Presence with FreeCAD, allowing users to display their current FreeCAD activity (such as the active workbench and file being edited) directly in Discord.
+This addon integrates Discord Rich Presence with FreeCAD, allowing users to display their current FreeCAD activity (such as the active workbench and file being edited) directly in Discord.
 
 ## Showcase
 https://github.com/user-attachments/assets/12f01ed2-5f9b-45a1-8aba-de352e99822d
-
-## Installation
-### Method 1 (install via addon manager):
-1. Discord Presence has been added to the FreeCAD-addons repository and can be installed from the built-in Addon Manager.
-
-![installImage](https://github.com/user-attachments/assets/a9b6dab0-45f9-4c52-831c-6399bc0981ed)
-
-### Method 2:
-1. Download/Clone the repository: You can clone or download this project to your local machine.
-
-2. Place the script in the Mod folder of freecad.
-    - On Linux it is usually /usr/share/freecad/Mod/
-    - On Windows it is usually C:\Program Files\FreeCAD\Mod\
-    - On macOS it is usually /Applications/FreeCAD/Mod/
 
 ## Features
 - Displays the current workbench in use within FreeCAD.
 - Shows the name of the file currently being edited.
 - Updates every second to reflect real-time changes in FreeCAD.
 - Automatically starts and stops when FreeCAD is running.
+
+## Installation
+### Automated (via Addon Manager)
+Discord Presence has been added to the FreeCAD-addons repository and therefore can be installed from the built-in [Addon Manager](https://wiki.freecad.org/Std_AddonMgr).
+
+### Manual
+
+<details><summary>Expand this section to read how to install Discord Rich Presence addon manually</summary>
+    
+1. Download/Clone the repository: You can clone or download this project to your local machine.
+2. Place the script in the Mod folder of freecad.
+    - On Linux it is usually /usr/share/freecad/Mod/
+    - On Windows it is usually C:\Program Files\FreeCAD\Mod\
+    - On macOS it is usually /Applications/FreeCAD/Mod/
+
+</details>
 
 ## Dependencies
 - ```pypresence```: Python library to manage Discord Rich Presence.


### PR DESCRIPTION
* moved Installation section below Feature section  
* removed screenshot of addon manager
* replaced with link to addon manager
* removed superfluous words
* hid manual installation instructions in collapsed div
* substituted 'extension' for 'addon'

Preview: https://github.com/luzpaz/FreecadDiscordPresence/blob/README-tweak/README.md