### PR TITLE
Import `PySide` instead of `PySide2`

### DIFF
--- a/discordPresence.py
+++ b/discordPresence.py
@@ -1,6 +1,6 @@
 import FreeCADGui
 import FreeCAD
-from PySide2 import QtCore
+from PySide import QtCore
 from pypresence import Presence
 import time
 import re


### PR DESCRIPTION
This addon imports `PySide2`, which may not always be available (for example, it isn't available on my system as I'm running Qt 6.8.1). According to https://forum.freecad.org/viewtopic.php?p=787258#p787258, the `PySide` package should be a safe replacement which chooses between `PySide2` and `PySide6` as appropriate.