### PR TITLE
Add instructions for Flatpak users

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ https://github.com/user-attachments/assets/12f01ed2-5f9b-45a1-8aba-de352e99822d
 3. Install the addon directly from the [Addon Manager](https://wiki.freecad.org/Std_AddonMgr).
 
 <details>
-  <summary><h2>Manual Installation</h2></summary>
+  <summary><h3>Manual Installation</h3></summary>
   <p>1. Clone or download this repository to your local machine:</p>
   <pre><code>git clone https://github.com/TzurSoffer/FreecadDiscordPresence</code></pre>
   
@@ -33,7 +33,7 @@ https://github.com/user-attachments/assets/12f01ed2-5f9b-45a1-8aba-de352e99822d
   <p>3. Restart FreeCAD to activate the addon.</p>
 </details>
 
-<details><summary><h2>Dependencies (automatically installed by addon manager)</h2></summary>
+<details><summary><h3>Dependencies (automatically installed by addon manager)</h3></summary>
 The addon requires the following Python library: <br>
 - <a href=https://github.com/qwertyquerty/pypresence><code>pypresence:</code></a> A library for managing Discord Rich Presence.
 </details>

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ The addon requires the following Python library: <br>
 - <a href=https://github.com/qwertyquerty/pypresence><code>pypresence:</code></a> A library for managing Discord Rich Presence.
 </details>
 
+**Note:** If you are on Linux and are using the Flatpak packaging of FreeCAD, run
+```
+flatpak override org.freecad.FreeCAD --user --filesystem=xdg-run/discord-ipc-0 --filesystem=xdg-run/app/com.discordapp.Discord
+```
+to grant FreeCAD the necessary permissions to communicate with Discord.
+
 ## How it works
 - The addon connects to Discord via the **rpc** protocol which can be read about on the [official discord page](https://discord.com/developers/docs/topics/rpc)
 - The app app fetches data about the current file and workbench through the FreeCAD api, updating your Discord presence to reflect that information.


### PR DESCRIPTION
When FreeCAD is packaged as a Flatpak, it by default does not have permissions to communicate with Discord due to Flatpak's sandboxing. This PR adds a note to the README that tells users how to grant FreeCAD the necessary Flatpak overrides. (It also moves the 'Manual Installation' and 'Dependencies' sections under the 'Installation' section.)